### PR TITLE
fix: deprecated `community.postgresql.postgresql_info` parameter `db`

### DIFF
--- a/molecule/postgresql/verify.yml
+++ b/molecule/postgresql/verify.yml
@@ -55,7 +55,7 @@
 
     - name: Test postgresql peer auth for root
       community.postgresql.postgresql_info:
-        db: postgres
+        login_db: postgres
         login_user: root
         filter: version
       register: _psql_result


### PR DESCRIPTION
The parameter is now called `login_db`. `db` got removed with community.postgresql.postgresql_info version 4.0.0 which caused our molecule tests to fail.

See https://github.com/ansible-collections/community.postgresql/blob/main/CHANGELOG.rst#removed-features-previously-deprecated