### PR TITLE
fix(tasks/encryption.yml): cut CN string when >64 chars

### DIFF
--- a/tasks/encryption.yml
+++ b/tasks/encryption.yml
@@ -32,7 +32,7 @@
   community.crypto.openssl_csr:
     path: /etc/bareos/{{ bareos_fd_hostname }}-public.csr
     privatekey_path: /etc/bareos/{{ bareos_fd_hostname }}-private.key
-    common_name: "{{ bareos_fd_hostname }}"
+    common_name: "{{ bareos_fd_hostname | truncate(64, true, '') }}"  # cn has max_length of 64 chars
     owner: bareos
     group: bareos
     mode: "0644"


### PR DESCRIPTION
Noticed this error for backup clients with a very long FQDN:
```
FAILED! => {"changed": false, "msg": "Attribute's length must be >= 1 and <= 64, but it was 72"} 
```

While we could use the short_hostname instead here, it does not really make sense to change the current approach IMO. 
This showed up for the first time after onboarding 200+ hosts and only for a test system with a cryptic FQDN. So this workaround should take care of potential future issues.
The Bareos encryption also doesn't care about the CN in the generated certificate. Tested both encrypted backup and restore.