### PR TITLE
feat: make no_log configurable and dont leak private keys

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,3 +103,6 @@ bareos_fd_plugin_psql_version: 15
 # This script will cleanup the files that are not necessary for the backup anymore.
 # This is disabled per default to avoid accidential file loss.
 bareos_fd_plugin_psql_wal_cleanup_enable: false
+
+# Do not log sensitive data
+bareos_fd_ansible_no_log: true

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -53,6 +53,10 @@ argument_specs:
         type: "list"
         default: []
         description: "The Messages to configure."
+      bareos_fd_ansible_no_log:
+        type: "bool"
+        default: true
+        description: "Prevent Ansible from logging sensitive data. Can be disabled for debugging."
       bareos_fd_encryption_enable:
         type: "bool"
         default: false

--- a/tasks/encryption.yml
+++ b/tasks/encryption.yml
@@ -24,6 +24,7 @@
     owner: bareos
     group: bareos
     mode: "0600"
+  no_log: "{{ bareos_fd_ansible_no_log | bool }}"
   when:
     - bareos_fd_encryption_private_key != ""
   ignore_errors: "{{ ansible_check_mode }}"
@@ -58,6 +59,7 @@
     owner: bareos
     group: bareos
     mode: "0600"
+  no_log: "{{ bareos_fd_ansible_no_log | bool }}"
   notify:
     - Check configuration
     - Restart bareos-filedaemon

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
     group: bareos
     mode: "0640"
     backup: "{{ bareos_fd_backup_configurations }}"
-  no_log: true
+  no_log: "{{ bareos_fd_ansible_no_log | bool }}"
   notify:
     - Check configuration
     - Restart bareos-filedaemon
@@ -83,7 +83,7 @@
   loop: "{{ bareos_fd_directors }}"
   loop_control:
     label: "{{ item.name }}"
-  no_log: true
+  no_log: "{{ bareos_fd_ansible_no_log | bool }}"
   notify:
     - Check configuration
     - Restart bareos-filedaemon


### PR DESCRIPTION
Hi,

This is a short follow up for https://github.com/adfinis/ansible-role-bareos_fd/commit/b189d3fc34e4c0cf41de97c379a1c53fad7de367

I found a few more tasks that might leak sensitive data.

Also, I think it would be usable if the `no_log` option was configurable, so that you can enable logging easily if you need to debug something.